### PR TITLE
Improvements and adaptions for EVerest release 2024.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ if(NOT DISABLE_EDM)
     evc_setup_edm()
 else()
     find_package(everest-core REQUIRED)
-    find_package(everest-framework REQUIRED)
 endif()
 
 ev_add_project()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.7)
 
 project(remotechargeport
-    VERSION 2024.02.0
+    VERSION 2024.05.0
     DESCRIPTION "EVerest modules for satellite charge ports"
     LANGUAGES CXX
 )

--- a/modules/SatelliteAgent/SatelliteAgent.cpp
+++ b/modules/SatelliteAgent/SatelliteAgent.cpp
@@ -244,12 +244,8 @@ void SatelliteAgent::init_rpc_binds() {
         return j.dump();
     });
 
-    this->rpc->bind("evse_manager_enable", [&](int& connector_id) {
-        return this->r_evse_manager->call_enable(connector_id);
-    });
-
-    this->rpc->bind("evse_manager_disable", [&](int& connector_id) {
-        return this->r_evse_manager->call_disable(connector_id);
+    this->rpc->bind("evse_manager_enable_disable", [&](int& connector_id, std::string& cmd_source) {
+        return this->r_evse_manager->call_enable_disable(connector_id, json::parse(cmd_source));
     });
 
     this->rpc->bind("evse_manager_authorize_response", [&](std::string& provided_token, std::string& validation_result) {

--- a/modules/SatelliteAgent/SatelliteAgent.hpp
+++ b/modules/SatelliteAgent/SatelliteAgent.hpp
@@ -66,6 +66,8 @@ public:
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
+
+    /// @brief Handle of an RPC server object, listing for incoming RPC connections.
     std::unique_ptr<rpc::server> rpc;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
@@ -81,27 +83,49 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+
+    /// @brief Remembers if the RPC peer already called the 'i_am_here' RPC function.
     bool i_am_here_seen{false};
+    /// @brief Used to signal a change in 'i_am_here_seen' to thread waiting in 'init'.
     std::condition_variable cv_i_am_here_seen;
+    /// @brief Mutex used for locks to protect the condition variable 'cv_i_am_here_seen'.
     std::mutex lock_i_am_here_seen;
 
+    /// @brief Remembers if the RPC peer already called the 'i_am_ready' RPC function.
     bool i_am_ready_seen{false};
+    /// @brief Used to signal a change in 'i_am_ready_seen' to thread waiting in 'init'.
     std::condition_variable cv_i_am_ready_seen;
+    /// @brief Mutex used for locks to protect the condition variable 'cv_i_am_ready_seen'.
     std::mutex lock_i_am_ready_seen;
 
+    /// @brief Used to tell the RPC handler thread that registration of 'real' RPC functions completed.
     bool i_am_ready_myself{false};
+    /// @brief Used to signal a change in 'i_am_ready_myself' to RPC handler thread.
     std::condition_variable cv_i_am_ready_myself;
+    /// @brief Mutex used for locks to protect the condition variable 'cv_i_am_ready_myself'.
     std::mutex lock_i_am_ready_myself;
 
+    /// @brief Accumulates all events which needs to be passed to the SatelliteController
+    ///        until it calls the RPC call "retrieve_vars". This call empties it, and then
+    ///        next events are accumulated again.
     json event_list;
+    /// @brief A flag indicating whether the event list grewed up to a threshold which
+    ///        triggers a warning and initiates a reboot.
     bool event_list_size_warned{false};
+    /// @brief Condition variable to signal a call to RPC function "retrieve_vars" to
+    ///        the observer functionality in 'ready'. This observer is used detect
+    ///        when periodic calls to this function are overdue.
     std::condition_variable cv_retrieve_vars_seen;
+    /// @brief Mutex used for locks to protect the condition variable 'cv_retrieve_vars_seen'.
     std::mutex event_list_guard;
 
     std::atomic_bool disconnect_expected{false};
 
+    /// @brief Helper to add an item to the event list.
     void add_to_event_list(std::string interface, std::string var, json value);
+    /// @brief Helper to register all 'real' RPC functors.
     void init_rpc_binds();
+    /// @brief Helper to initiate a reset.
     void trigger_reset();
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };

--- a/modules/SatelliteAgent/SatelliteAgent.hpp
+++ b/modules/SatelliteAgent/SatelliteAgent.hpp
@@ -23,6 +23,7 @@
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -80,12 +81,28 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    std::atomic_bool initial_connect{false};
+    bool i_am_here_seen{false};
+    std::condition_variable cv_i_am_here_seen;
+    std::mutex lock_i_am_here_seen;
+
+    bool i_am_ready_seen{false};
+    std::condition_variable cv_i_am_ready_seen;
+    std::mutex lock_i_am_ready_seen;
+
+    bool i_am_ready_myself{false};
+    std::condition_variable cv_i_am_ready_myself;
+    std::mutex lock_i_am_ready_myself;
 
     json event_list;
+    bool event_list_size_warned{false};
+    std::condition_variable cv_retrieve_vars_seen;
     std::mutex event_list_guard;
 
+    std::atomic_bool disconnect_expected{false};
+
     void add_to_event_list(std::string interface, std::string var, json value);
+    void init_rpc_binds();
+    void trigger_reset();
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/SatelliteController/SatelliteController.cpp
+++ b/modules/SatelliteController/SatelliteController.cpp
@@ -30,7 +30,8 @@ void SatelliteController::init() {
     //
     // register all callbacks for our desired interfaces
     // note: the callbacks are supposed to be not called yet since we are still in init phase;
-    //       otherwise dereferencing of rpc would occur are we would crash
+    //       otherwise dereferencing of rpc would occur and we would crash
+    //       (per definition, rpc has to be set up and running once we go from 'init' to 'ready')
     //
     this->r_auth->subscribe_token_validation_status([&](types::authorization::TokenValidationStatusMessage value) {
         json j = json::object({ {"interface", "auth"},
@@ -39,6 +40,7 @@ void SatelliteController::init() {
         this->rpc->call("push_var", j.dump());
     });
 
+    // the manifest allows system to be not linked to a real module
     if (not this->r_system.empty()) {
         this->r_system[0]->subscribe_firmware_update_status([&](types::system::FirmwareUpdateStatus value) {
             json j = json::object({ {"interface", "system"},

--- a/modules/SatelliteController/SatelliteController.cpp
+++ b/modules/SatelliteController/SatelliteController.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright Pionix GmbH and Contributors to EVerest
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <string>
 #include <thread>
-#include <chrono>
 #include "SatelliteController.hpp"
 #include <rpc/client.h>
+#include <rpc/rpc_error.h>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
@@ -15,7 +16,9 @@ using namespace std::chrono_literals;
 namespace module {
 
 SatelliteController::~SatelliteController() {
-    this->rpc->call("exit");
+    // if still connected, tell the peer that we are quitting now
+    if (this->rpc->get_connection_state() == rpc::client::connection_state::connected)
+        this->rpc->call("exit");
 }
 
 void SatelliteController::init() {
@@ -24,8 +27,11 @@ void SatelliteController::init() {
     invoke_init(*p_evse_manager);
     invoke_init(*p_system);
 
-    this->rpc = std::make_unique<rpc::client>(this->config.hostname, this->config.port);
-
+    //
+    // register all callbacks for our desired interfaces
+    // note: the callbacks are supposed to be not called yet since we are still in init phase;
+    //       otherwise dereferencing of rpc would occur are we would crash
+    //
     this->r_auth->subscribe_token_validation_status([&](types::authorization::TokenValidationStatusMessage value) {
         json j = json::object({ {"interface", "auth"},
                                 {"var", "token_validation_status"},
@@ -49,7 +55,43 @@ void SatelliteController::init() {
         });
     }
 
+    //
+    // we need a two step approach here to handle cases when satellite and ourself lost synchronization
+    //
+    EVLOG_info << "Connecting to SatelliteAgent on " << this->config.hostname << ":" << this->config.port << "...";
+    bool i_am_here_rv{true};
+
+    do {
+        // assigning this variable should call the destructor of previous instance if already set -> closes connection
+        try {
+            this->rpc = std::make_unique<rpc::client>(this->config.hostname, this->config.port);
+
+            // then next RPC calls should not take longer than this timeout
+            std::chrono::milliseconds timeout{5s};
+            this->rpc->set_timeout(timeout.count()); /* takes [ms] as argument */
+
+            // the 'i_am_here' call returns true in case the peer has seen us before (and is not in boot-up sync phase anymore)
+            EVLOG_debug << "Signaling 'i_am_here'...";
+            i_am_here_rv = this->rpc->call("i_am_here").as<bool>();
+            EVLOG_debug << "...got: " << i_am_here_rv;
+
+        } catch (const rpc::system_error& e) {
+            // keep retrying on connect errors (with a small delay)
+            std::this_thread::sleep_for(1s);
+            continue;
+        } catch (const rpc::timeout& e) {
+            // keep retrying on timeout (without further delay)
+            continue;
+        }
+    } while (i_am_here_rv);
+
+    // once 'i_am_here' returned, we are allowed to call all other RPC callbacks as well
+    // let's move from 'init' phase to 'ready' simultaneously with peer
+    EVLOG_debug << "Signaling 'i_am_ready'...";
     this->rpc->call("i_am_ready");
+
+    // clear the global timeout again, we want usual RPC calls to "hang" when connection is lost
+    this->rpc->clear_timeout();
 }
 
 void SatelliteController::ready() {
@@ -59,7 +101,13 @@ void SatelliteController::ready() {
     invoke_ready(*p_system);
 
     while (this->rpc->get_connection_state() == rpc::client::connection_state::connected) {
-        json event_list = json::parse(this->rpc->call("retrieve_vars").as<std::string>());
+        // we don't use a sync call here since we want to use our own timeout here
+        auto future = this->rpc->async_call("retrieve_vars");
+        auto wait_result = future.wait_for(30s); // we need this large timeout at the moment due to OCPP GetDiagnostics upload
+        if (wait_result == std::future_status::timeout)
+            break;
+
+        json event_list = json::parse(future.get().as<std::string>());
 
         for (auto& event : event_list) {
             if (event["interface"] == "auth_token_provider") {
@@ -109,10 +157,11 @@ void SatelliteController::ready() {
         std::this_thread::sleep_for(25ms);
     }
 
-    EVLOG_info << "Connection to remote agent lost. Terminating...";
+    EVLOG_info << "Connection to SatelliteAgent on " << this->config.hostname << ":" << this->config.port << " lost. Terminating...";
 
     if (not this->disconnect_expected) {
-        std::exit(0);
+        EVLOG_warning << "...and since this was not expected, we terminate the whole EVerest.";
+        std::exit(1);
     }
 }
 

--- a/modules/SatelliteController/SatelliteController.hpp
+++ b/modules/SatelliteController/SatelliteController.hpp
@@ -66,8 +66,10 @@ public:
     // insert your public definitions here
     ~SatelliteController();
 
+    /// @brief Handle of an RPC client object, connecting to a SatelliteAgent instance
     std::unique_ptr<rpc::client> rpc;
 
+    /// @brief Used to remember whether a (possible) disconnect in the future is expected.
     std::atomic_bool disconnect_expected{false};
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 

--- a/modules/SatelliteController/evse_manager/evse_managerImpl.cpp
+++ b/modules/SatelliteController/evse_manager/evse_managerImpl.cpp
@@ -21,12 +21,10 @@ types::evse_manager::Evse evse_managerImpl::handle_get_evse() {
     return j;
 }
 
-bool evse_managerImpl::handle_enable(int& connector_id) {
-    return this->mod->rpc->call("evse_manager_enable", connector_id).as<bool>();
-}
+bool evse_managerImpl::handle_enable_disable(int& connector_id, types::evse_manager::EnableDisableSource& cmd_source) {
+    json j = cmd_source;
 
-bool evse_managerImpl::handle_disable(int& connector_id) {
-    return this->mod->rpc->call("evse_manager_disable", connector_id).as<bool>();
+    return this->mod->rpc->call("evse_manager_enable_disable", connector_id, j.dump()).as<bool>();
 }
 
 void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,

--- a/modules/SatelliteController/evse_manager/evse_managerImpl.hpp
+++ b/modules/SatelliteController/evse_manager/evse_managerImpl.hpp
@@ -34,8 +34,8 @@ public:
 protected:
     // command handler functions (virtual)
     virtual types::evse_manager::Evse handle_get_evse() override;
-    virtual bool handle_enable(int& connector_id) override;
-    virtual bool handle_disable(int& connector_id) override;
+    virtual bool handle_enable_disable(int& connector_id,
+                                       types::evse_manager::EnableDisableSource& cmd_source) override;
     virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
                                            types::authorization::ValidationResult& validation_result) override;
     virtual void handle_withdraw_authorization() override;

--- a/modules/SatelliteController/system/systemImpl.cpp
+++ b/modules/SatelliteController/system/systemImpl.cpp
@@ -18,12 +18,18 @@ void systemImpl::ready() {
 
 types::system::UpdateFirmwareResponse
 systemImpl::handle_update_firmware(types::system::FirmwareUpdateRequest& firmware_update_request) {
+    types::system::UpdateFirmwareResponse rv;
     json j = firmware_update_request;
-    std::string rv;
+    std::string rpc_rv;
 
-    rv = this->mod->rpc->call("system_update_firmware", j.dump()).as<std::string>();
+    rpc_rv = this->mod->rpc->call("system_update_firmware", j.dump()).as<std::string>();
+    rv = types::system::string_to_update_firmware_response(rpc_rv);
 
-    return types::system::string_to_update_firmware_response(rv);
+    if (rv == types::system::UpdateFirmwareResponse::Accepted) {
+        this->mod->disconnect_expected = true;
+    }
+
+    return rv;
 }
 
 void systemImpl::handle_allow_firmware_installation() {

--- a/modules/SystemAggregator/SystemAggregator.hpp
+++ b/modules/SystemAggregator/SystemAggregator.hpp
@@ -56,6 +56,12 @@ public:
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
 
+    // remember incoming status messages/counters and mutex to protect
+    std::map<types::system::FirmwareUpdateStatusEnum, unsigned int> fw_update_feedback_counter;
+    std::map<types::system::FirmwareUpdateStatusEnum, bool> fw_update_already_reported;
+    bool fw_update_final_one_reported;
+    std::mutex lock_fw_update_status;
+
     // maps for all ongoing log upload requests
     std::map<int32_t, systemaggregator_upload_log_request> log_uploads;
     std::map<std::string, int32_t> type_to_log_uploads_map;

--- a/modules/SystemAggregator/system/systemImpl.cpp
+++ b/modules/SystemAggregator/system/systemImpl.cpp
@@ -29,6 +29,13 @@ void systemImpl::ready() {
 
 types::system::UpdateFirmwareResponse
 systemImpl::handle_update_firmware(types::system::FirmwareUpdateRequest& firmware_update_request) {
+    std::scoped_lock lock(this->mod->lock_fw_update_status);
+
+    // clear boths maps which remembered status of last operation
+    this->mod->fw_update_feedback_counter.clear();
+    this->mod->fw_update_already_reported.clear();
+    this->mod->fw_update_final_one_reported = false;
+
     std::vector<types::system::UpdateFirmwareResponse> rvs;
 
     for (auto& system : this->mod->r_system) {

--- a/modules/SystemAggregator/system/systemImpl.cpp
+++ b/modules/SystemAggregator/system/systemImpl.cpp
@@ -73,6 +73,9 @@ std::string systemImpl::create_logs_filename(std::string type) {
     if (ts.find(".") != std::string::npos)
        ts = ts.substr(0, ts.find("."));
 
+    // add 'Z' suffix to indicate Zulu time
+    ts += "Z";
+
     return type + "_" + ts + ".tar.gz";
 }
 


### PR DESCRIPTION
This PR adapts the modules for latest EVerest 2024.5.0 release.

It also improves the initial synchronization mechanism and thus should make workflows like OCPP firmware updates more reliable.